### PR TITLE
#30 Added feature for "Add setting to modify the prefix or suffix of the backup files"

### DIFF
--- a/AutoBackups (Linux).sublime-settings
+++ b/AutoBackups (Linux).sublime-settings
@@ -19,6 +19,12 @@
 	// to use this feature, you must have enabled backup_per_day setting
 	"backup_per_time": "file",
 
+	// If, set will change the name of the file according to mode:
+	// prefix: "auto-save.myfile_095034.php"
+	// suffix: myfile_095034.auto-save.php
+	// if None or false won't change the name
+	"backup_name_mode":"prefix",
+
 	// Files larger than this many bytes won't be backed up.
 	"max_backup_file_size_bytes": 262144, // = 256 KB
 

--- a/AutoBackups (OSX).sublime-settings
+++ b/AutoBackups (OSX).sublime-settings
@@ -19,6 +19,12 @@
 	// to use this feature, you must have enabled backup_per_day setting
 	"backup_per_time": "file",
 
+	// If, set will change the name of the file according to mode:
+	// prefix: "auto-save.myfile_095034.php"
+	// suffix: myfile_095034.auto-save.php
+	// if None or false won't change the name
+	"backup_name_mode":"prefix",
+
 	// Files larger than this many bytes won't be backed up.
 	"max_backup_file_size_bytes": 262144, // = 256 KB
 

--- a/AutoBackups (Windows).sublime-settings
+++ b/AutoBackups (Windows).sublime-settings
@@ -19,6 +19,12 @@
 	// to use this feature, you must have enabled backup_per_day setting
 	"backup_per_time": "file",
 
+	// If, set will change the name of the file according to mode:
+	// prefix: "auto-save.myfile_095034.php"
+	// suffix: myfile_095034.auto-save.php
+	// if None or false won't change the name
+	"backup_name_mode":"prefix",
+
 	// Files larger than this many bytes won't be backed up.
 	"max_backup_file_size_bytes": 262144, // = 256 KB
 

--- a/AutoBackups.py
+++ b/AutoBackups.py
@@ -60,9 +60,14 @@ def plugin_loaded():
     backup_dir = settings.get('backup_dir')
     backup_per_day = settings.get('backup_per_day')
     backup_per_time = settings.get('backup_per_time')
+    backup_name_mode = settings.get('backup_name_mode')
 
-    PathsHelper.initialize(platform, backup_dir, backup_per_day, backup_per_time)
+    PathsHelper.initialize(platform, backup_dir, backup_per_day, backup_per_time, backup_name_mode)
     cprint('AutoBackups: Plugin Initialized')
+    cprint('With: backup_dir: {}\n\
+            backup_per_day: {}\n\
+            backup_per_time: {}\n\
+            backup_name_mode: {}'.format(backup_dir, backup_per_day, backup_per_time, backup_name_mode))
     sublime.set_timeout(gc, 10000)
 
 
@@ -130,8 +135,6 @@ class AutoBackupsEventListener(sublime_plugin.EventListener):
         if self.is_excluded(filename):
             #cprint("AutoBackups: " + filename + " is excluded");
             return
-
-
 
         # not create file backup if current file is backup
         if on_load_event & self.is_backup_file(filename):

--- a/autobackups/paths_helper.py
+++ b/autobackups/paths_helper.py
@@ -21,6 +21,8 @@ class PathsHelper(object):
     backup_dir = False
     backup_per_day = False
     backup_per_time = False
+    backup_name_mode = False
+
 
     @staticmethod
     def initialize(pl, backup_dir, backup_per_day, backup_per_time, backup_name_mode):

--- a/autobackups/paths_helper.py
+++ b/autobackups/paths_helper.py
@@ -13,6 +13,9 @@ import re
 import sys
 import datetime
 
+
+backup_name_mode_text = 'auto-save'
+
 class PathsHelper(object):
     platform = False
     backup_dir = False
@@ -20,11 +23,12 @@ class PathsHelper(object):
     backup_per_time = False
 
     @staticmethod
-    def initialize(pl, backup_dir, backup_per_day, backup_per_time):
+    def initialize(pl, backup_dir, backup_per_day, backup_per_time, backup_name_mode):
         PathsHelper.platform = pl
         PathsHelper.backup_dir = backup_dir
         PathsHelper.backup_per_day = backup_per_day
         PathsHelper.backup_per_time = backup_per_time
+        PathsHelper.backup_name_mode = backup_name_mode
 
 
     @staticmethod
@@ -60,8 +64,12 @@ class PathsHelper(object):
         return os.path.expanduser(backup_dir)
 
     @staticmethod
-    def timestamp_file(filename):
+    def create_name_file(filename):
         (filepart, extensionpart) = os.path.splitext(filename)
+
+        if PathsHelper.backup_name_mode not in (False, None, ) \
+          and PathsHelper.backup_name_mode.lower() == 'prefix':
+            filepart = '%s.%s' % (backup_name_mode_text, filepart)
 
         backup_per_day =  PathsHelper.backup_per_day
         backup_per_time =  PathsHelper.backup_per_time
@@ -71,6 +79,11 @@ class PathsHelper(object):
             name = '%s_%s%s' % (filepart, time, extensionpart,)
         else:
             name = '%s%s' % (filepart, extensionpart,)
+
+        (filepart, extensionpart) = os.path.splitext(name) 
+        if PathsHelper.backup_name_mode not in (False, None, ) \
+          and PathsHelper.backup_name_mode.lower() == 'suffix':
+            name = '%s.%s%s' % (filepart, backup_name_mode_text, extensionpart)
         return name
 
     @staticmethod
@@ -109,5 +122,5 @@ class PathsHelper(object):
     @staticmethod
     def get_backup_filepath(filepath):
         filename = os.path.split(filepath)[1]
-        return os.path.join(PathsHelper.get_backup_path(filepath), PathsHelper.timestamp_file(filename))
+        return os.path.join(PathsHelper.get_backup_path(filepath), PathsHelper.create_name_file(filename))
 


### PR DESCRIPTION
#30 

Added the feature for saving the backup files with a prefix or a suffix.

- Modified the settings: added a new option "backup_name_mode" where is possible to choose between "suffix" and "predix" or None/false 

for this version the prefix/suffix is: "auto-save" it's possible to change modifying the pathhelper.py file.

- [x]  Tested on Windows Sublime Text 3
- [x]  Tested on Mac Sublime Text 3
- [x]  Tested on Linux Sublime Text 3
- [ ]  Tested on Windows Sublime Text 2
- [ ]  Tested on Mac Sublime Text 2
- [ ]  Tested on Linux Sublime Text 2

##  Future development 
-  Adding the possibility to change the suffix/predix string according to the settings